### PR TITLE
Add BM3D OpenCV wrapper and build files

### DIFF
--- a/Bm3dGpu.cpp
+++ b/Bm3dGpu.cpp
@@ -1,0 +1,45 @@
+#include "Bm3dGpu.h"
+#include "bm3d.hpp"
+
+#include <opencv2/imgproc.hpp>
+#include <memory>
+
+Bm3dGpu::Bm3dGpu(float sigma, bool two_step)
+    : impl_(new BM3D()), two_step_(two_step), default_sigma_(sigma) {
+    impl_->set_hard_params(19, 8, 16, 2500, 3, 2.7f);
+    impl_->set_wien_params(19, 8, 32, 400, 3);
+    impl_->set_verbose(false);
+}
+
+cv::Mat Bm3dGpu::operator()(const cv::Mat& src, float sigma) {
+    CV_Assert(src.channels() == 1);
+
+    float used_sigma = sigma;
+    if (sigma < 0.f)
+        used_sigma = default_sigma_;
+
+    cv::Mat src8;
+    bool is16 = src.depth() == CV_16U;
+    if (is16) {
+        src.convertTo(src8, CV_8U, 1.0 / 256.0);
+    } else {
+        src8 = src.clone();
+    }
+
+    cv::Mat dst8(src8.size(), CV_8U);
+    unsigned int sigma2 = static_cast<unsigned int>(used_sigma * used_sigma);
+    impl_->denoise_host_image(src8.data, dst8.data,
+                              src8.cols, src8.rows, 1,
+                              &sigma2, two_step_);
+
+    if (is16) {
+        cv::Mat dst16;
+        dst8.convertTo(dst16, CV_16U, 256.0);
+        return dst16;
+    }
+    return dst8;
+}
+
+Bm3dGpu::~Bm3dGpu() {
+    delete impl_;
+}

--- a/Bm3dGpu.h
+++ b/Bm3dGpu.h
@@ -1,0 +1,63 @@
+#pragma once
+
+#include <opencv2/core.hpp>
+#include <cuda_runtime.h>
+#include "params.hpp"
+
+// Expose kernels from original CUDA code
+extern "C" {
+void run_block_matching(const uchar* image, ushort* stacks, uint* num_patches_in_stack,
+                        const uint2 image_dim, const uint2 stacks_dim, const Params params,
+                        const uint2 start_point, const dim3 num_threads, const dim3 num_blocks,
+                        const uint shared_memory_size);
+
+void run_get_block(const uint2 start_point, const uchar* image, const ushort* stacks,
+                   const uint* num_patches_in_stack, float* patch_stack, const uint2 image_dim,
+                   const uint2 stacks_dim, const Params params, const dim3 num_threads,
+                   const dim3 num_blocks);
+
+void run_DCT2D8x8(float* d_transformed_stacks, const float* d_gathered_stacks, const uint size,
+                  const dim3 num_threads, const dim3 num_blocks);
+
+void run_hard_treshold_block(const uint2 start_point, float* patch_stack, float* w_P,
+                             const uint* num_patches_in_stack, const uint2 stacks_dim,
+                             const Params params, const uint sigma,
+                             const dim3 num_threads, const dim3 num_blocks,
+                             const uint shared_memory_size);
+
+void run_IDCT2D8x8(float* d_gathered_stacks, const float* d_transformed_stacks, const uint size,
+                   const dim3 num_threads, const dim3 num_blocks);
+
+void run_aggregate_block(const uint2 start_point, const float* patch_stack, const float* w_P,
+                         const ushort* stacks, const float* kaiser_window,
+                         float* numerator, float* denominator,
+                         const uint* num_patches_in_stack, const uint2 image_dim,
+                         const uint2 stacks_dim, const Params params,
+                         const dim3 num_threads, const dim3 num_blocks);
+
+void run_aggregate_final(const float* numerator, const float* denominator,
+                         const uint2 image_dim, uchar* denoised_image,
+                         const dim3 num_threads, const dim3 num_blocks);
+
+void run_wiener_filtering(const uint2 start_point, float* patch_stack,
+                          const float* patch_stack_basic, float* w_P,
+                          const uint* num_patches_in_stack, uint2 stacks_dim,
+                          const Params params, const uint sigma,
+                          const dim3 num_threads, const dim3 num_blocks,
+                          const uint shared_memory_size);
+}
+
+class BM3D; // forward declaration
+
+class Bm3dGpu {
+public:
+    explicit Bm3dGpu(float sigma = 15.0f, bool two_step = false);
+    ~Bm3dGpu();
+
+    cv::Mat operator()(const cv::Mat& src, float sigma = 15.0f);
+
+private:
+    BM3D* impl_;
+    bool two_step_;
+    float default_sigma_;
+};

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,25 +1,36 @@
-cmake_minimum_required(VERSION 3.8 FATAL_ERROR)
-project(bm3d LANGUAGES CXX CUDA)
+cmake_minimum_required(VERSION 3.18)
+project(bm3d_gpu LANGUAGES CXX CUDA)
 
-include_directories(
-	${CMAKE_CURRENT_SOURCE_DIR}/include
-	${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES}
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# Silence warnings about unknown compiler features with older CMake
+if(POLICY CMP0125)
+  cmake_policy(SET CMP0125 NEW)
+endif()
+
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
+
+set(SRC
+    src/blockmatching.cu
+    src/dct8x8.cu
+    src/filtering.cu
+    Bm3dGpu.cpp
 )
 
-set(CMAKE_CXX_STANDARD 11)
-set(CMAKE_CXX_STANDARD_REQUIRED True)
+add_library(bm3d_gpu STATIC ${SRC})
 
-# The following lines build the main executable.
-add_executable(bm3d
-	include/CImg.h
-	include/stopwatch.hpp
-	include/indices.cuh
-	include/params.hpp
-	include/bm3d.hpp
-	src/filtering.cu
-	src/blockmatching.cu
-	src/dct8x8.cu
-	src/main_nodisplay.cpp
-)
+target_link_libraries(bm3d_gpu PUBLIC cudart cufft)
 
-target_link_libraries(bm3d cufft cudart png)
+target_include_directories(bm3d_gpu PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+    $<INSTALL_INTERFACE:include>)
+
+find_package(OpenCV REQUIRED)
+
+target_link_libraries(bm3d_gpu PUBLIC ${OpenCV_LIBS})
+target_include_directories(bm3d_gpu PUBLIC ${OpenCV_INCLUDE_DIRS})
+
+add_executable(demo demo.cpp)
+
+target_link_libraries(demo PRIVATE bm3d_gpu ${OpenCV_LIBS})

--- a/demo.cpp
+++ b/demo.cpp
@@ -1,0 +1,10 @@
+#include <opencv2/imgcodecs.hpp>
+#include "Bm3dGpu.h"
+
+int main() {
+    cv::Mat noisy = cv::imread("frame.tiff", cv::IMREAD_UNCHANGED);
+    Bm3dGpu denoiser(15.0f);
+    cv::Mat clean = denoiser(noisy);
+    cv::imwrite("clean.tiff", clean);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add `Bm3dGpu` wrapper for using bm3d CUDA kernels from OpenCV
- provide headers exposing original kernel prototypes
- create minimal CMake build that outputs `libbm3d_gpu.a` and demo program

## Testing
- `cmake ..`
- `make -j2`


------
https://chatgpt.com/codex/tasks/task_e_684656076fac8327bce9cacbbba5e7f4